### PR TITLE
Implement data-contentbefore and data-contentafter attributes

### DIFF
--- a/src/contentarea.ts
+++ b/src/contentarea.ts
@@ -557,7 +557,7 @@ function diff(
 				if (nodeInfo.f & IS_OLD) {
 					oldIndex += nodeInfo.length;
 				}
-			} else if ((node as Element).hasAttribute("data-content")) {
+			} else if (node !== _this && (node as Element).hasAttribute("data-content")) {
 				const text = (node as Element).getAttribute("data-content") || "";
 				if (text.length) {
 					value += text;
@@ -571,7 +571,7 @@ function diff(
 					oldIndex += nodeInfo.length;
 				}
 			} else {
-				const beforeText = (node as Element).getAttribute?.("data-contentbefore") || "";
+				const beforeText = node !== _this ? (node as Element).getAttribute?.("data-contentbefore") || "" : "";
 				descending = !!walker.firstChild();
 				if (descending) {
 					stack.push({nodeInfo, oldIndexRelative});
@@ -612,6 +612,7 @@ function diff(
 			if (!(nodeInfo.f & IS_VALID)) {
 				// data-contentafter: add virtual text after children
 				if (
+					node !== _this &&
 					node.nodeType === Node.ELEMENT_NODE &&
 					node.nodeName !== "BR" &&
 					!(node as Element).hasAttribute("data-content")

--- a/src/contentarea.ts
+++ b/src/contentarea.ts
@@ -557,6 +557,8 @@ function diff(
 					hasNewline = text.endsWith(NEWLINE);
 				}
 
+				nodeInfo.beforeLength = 0;
+				nodeInfo.afterLength = 0;
 				if (nodeInfo.f & IS_OLD) {
 					oldIndex += nodeInfo.length;
 				}

--- a/src/contentarea.ts
+++ b/src/contentarea.ts
@@ -836,6 +836,8 @@ function findNodeOffset(
 				const ni = cache.get(node)!;
 				if (ni.beforeLength > 0) {
 					if (index < ni.beforeLength) {
+						// Virtual prefix text has no DOM positions, so indices
+						// inside it collapse to the start of the element.
 						return [node, 0];
 					}
 					index -= ni.beforeLength;

--- a/src/contentarea.ts
+++ b/src/contentarea.ts
@@ -847,7 +847,9 @@ function findNodeOffset(
 			const firstChild = walker.firstChild();
 			if (firstChild === null) {
 				const offset =
-					node.nodeType === Node.TEXT_NODE ? index : index > 0 ? 1 : 0;
+					node.nodeType === Node.TEXT_NODE
+						? index
+						: Math.min(index > 0 ? 1 : 0, getNodeLength(node));
 				return [node, offset];
 			} else {
 				node = firstChild;

--- a/src/contentarea.ts
+++ b/src/contentarea.ts
@@ -738,10 +738,10 @@ function indexAt(
 			index = 0;
 		} else if (offset >= node.childNodes.length) {
 			const nodeInfo = cache.get(node)!;
-			index =
-				nodeInfo.f & APPENDS_NEWLINE
-					? nodeInfo.length - NEWLINE.length
-					: nodeInfo.length;
+			index = nodeInfo.length - nodeInfo.afterLength;
+			if (nodeInfo.f & APPENDS_NEWLINE) {
+				index -= NEWLINE.length;
+			}
 		} else {
 			let child: Node | null = node.childNodes[offset];
 			while (child !== null && !cache.has(child)) {

--- a/src/contentarea.ts
+++ b/src/contentarea.ts
@@ -65,9 +65,8 @@ export class ContentAreaElement extends HTMLElement {
 			attributeOldValue: true,
 			attributeFilter: [
 				"data-content",
-				// TODO: implement these attributes
-				//"data-contentbefore",
-				//"data-contentafter",
+				"data-contentbefore",
+				"data-contentafter",
 			],
 		});
 		document.addEventListener(
@@ -313,11 +312,17 @@ class NodeInfo {
 	declare offset: number;
 	/** The string length of this node’s contents. */
 	declare length: number;
+	/** The string length of the data-contentbefore virtual text. */
+	declare beforeLength: number;
+	/** The string length of the data-contentafter virtual text. */
+	declare afterLength: number;
 
 	constructor(offset: number) {
 		this.f = 0;
 		this.offset = offset;
 		this.length = 0;
+		this.beforeLength = 0;
+		this.afterLength = 0;
 	}
 }
 
@@ -563,11 +568,30 @@ function diff(
 					oldIndex += nodeInfo.length;
 				}
 			} else {
+				const beforeText = (node as Element).getAttribute?.("data-contentbefore") || "";
 				descending = !!walker.firstChild();
 				if (descending) {
 					stack.push({nodeInfo, oldIndexRelative});
-					offset = 0;
 					oldIndexRelative = oldIndex;
+					if (nodeInfo.f & IS_OLD) {
+						oldIndex += nodeInfo.beforeLength;
+					}
+					nodeInfo.beforeLength = beforeText.length;
+					offset = beforeText.length;
+					if (beforeText.length) {
+						value += beforeText;
+						hasNewline = beforeText.endsWith(NEWLINE);
+					}
+				} else {
+					if (beforeText.length) {
+						value += beforeText;
+						offset += beforeText.length;
+						hasNewline = beforeText.endsWith(NEWLINE);
+					}
+					if (nodeInfo.f & IS_OLD) {
+						oldIndex += nodeInfo.beforeLength;
+					}
+					nodeInfo.beforeLength = beforeText.length;
 				}
 			}
 		} else {
@@ -583,6 +607,23 @@ function diff(
 		if (!descending) {
 			// POST-ORDER LOGIC
 			if (!(nodeInfo.f & IS_VALID)) {
+				// data-contentafter: add virtual text after children
+				if (
+					node.nodeType === Node.ELEMENT_NODE &&
+					!(node as Element).hasAttribute("data-content")
+				) {
+					const afterText = (node as Element).getAttribute("data-contentafter") || "";
+					if (afterText.length) {
+						value += afterText;
+						offset += afterText.length;
+						hasNewline = afterText.endsWith(NEWLINE);
+					}
+					if (nodeInfo.f & IS_OLD) {
+						oldIndex += nodeInfo.afterLength;
+					}
+					nodeInfo.afterLength = afterText.length;
+				}
+
 				// Skip past the old appended newline in oldValue. Only needed
 				// for elements whose children were re-walked, since leaf-like
 				// nodes already include APPENDS_NEWLINE in nodeInfo.length.
@@ -785,11 +826,18 @@ function findNodeOffset(
 
 			node = nextSibling;
 		} else {
-			if (
-				node.nodeType === Node.ELEMENT_NODE &&
-				(node as Element).hasAttribute("data-content")
-			) {
-				return nodeOffsetFromChild(node, index > 0);
+			if (node.nodeType === Node.ELEMENT_NODE) {
+				if ((node as Element).hasAttribute("data-content")) {
+					return nodeOffsetFromChild(node, index > 0);
+				}
+
+				const ni = cache.get(node)!;
+				if (ni.beforeLength > 0) {
+					if (index < ni.beforeLength) {
+						return [node, 0];
+					}
+					index -= ni.beforeLength;
+				}
 			}
 
 			const firstChild = walker.firstChild();

--- a/src/contentarea.ts
+++ b/src/contentarea.ts
@@ -741,6 +741,10 @@ function indexAt(
 		if (offset <= 0) {
 			index = 0;
 		} else if (offset >= node.childNodes.length) {
+			// Virtual suffix text (data-contentafter, APPENDS_NEWLINE) has no DOM
+			// positions, so this maps to the end of real children, not the end
+			// of the suffix. Indices inside virtual text are lossy through DOM
+			// selection APIs by design.
 			const nodeInfo = cache.get(node)!;
 			index = nodeInfo.length - nodeInfo.afterLength;
 			if (nodeInfo.f & APPENDS_NEWLINE) {

--- a/src/contentarea.ts
+++ b/src/contentarea.ts
@@ -549,6 +549,14 @@ function diff(
 				if (nodeInfo.f & IS_OLD) {
 					oldIndex += nodeInfo.length;
 				}
+			} else if (node.nodeName === "BR") {
+				// BR always produces a newline; data-content* attributes are ignored.
+				value += NEWLINE;
+				offset += NEWLINE.length;
+				hasNewline = true;
+				if (nodeInfo.f & IS_OLD) {
+					oldIndex += nodeInfo.length;
+				}
 			} else if ((node as Element).hasAttribute("data-content")) {
 				const text = (node as Element).getAttribute("data-content") || "";
 				if (text.length) {
@@ -559,13 +567,6 @@ function diff(
 
 				nodeInfo.beforeLength = 0;
 				nodeInfo.afterLength = 0;
-				if (nodeInfo.f & IS_OLD) {
-					oldIndex += nodeInfo.length;
-				}
-			} else if (node.nodeName === "BR") {
-				value += NEWLINE;
-				offset += NEWLINE.length;
-				hasNewline = true;
 				if (nodeInfo.f & IS_OLD) {
 					oldIndex += nodeInfo.length;
 				}
@@ -612,6 +613,7 @@ function diff(
 				// data-contentafter: add virtual text after children
 				if (
 					node.nodeType === Node.ELEMENT_NODE &&
+					node.nodeName !== "BR" &&
 					!(node as Element).hasAttribute("data-content")
 				) {
 					const afterText = (node as Element).getAttribute("data-contentafter") || "";

--- a/test/contentarea.ts
+++ b/test/contentarea.ts
@@ -1250,6 +1250,10 @@ let area!: ContentAreaElement;
 	test("leaf element with data-contentbefore and data-contentafter", () => {
 		area.innerHTML = '<span data-contentbefore="(" data-contentafter=")"></span>';
 		Assert.is(area.value, "()");
+
+		// nodeOffsetAt inside suffix of empty element must not return invalid offset
+		const [node, offset] = area.nodeOffsetAt(1);
+		Assert.ok(offset <= (node as Element).childNodes.length);
 	});
 
 	test("block element with data-contentbefore", () => {

--- a/test/contentarea.ts
+++ b/test/contentarea.ts
@@ -1151,3 +1151,112 @@ let area!: ContentAreaElement;
 
 	test.run();
 }
+
+{
+	const test = suite("ContentAreaElement data-contentbefore/data-contentafter");
+	test.before(() => {
+		if (!window.customElements.get("content-area")) {
+			window.customElements.define("content-area", ContentAreaElement);
+		}
+	});
+
+	test.before.each(() => {
+		document.body.innerHTML = "<content-area></content-area>";
+		area = document.body.firstChild as ContentAreaElement;
+	});
+
+	test("data-contentbefore adds text before children", () => {
+		area.innerHTML = '<span data-contentbefore=">>> ">Hello</span>';
+		Assert.is(area.value, ">>> Hello");
+	});
+
+	test("data-contentafter adds text after children", () => {
+		area.innerHTML = '<span data-contentafter=" <<<">Hello</span>';
+		Assert.is(area.value, "Hello <<<");
+	});
+
+	test("both data-contentbefore and data-contentafter together", () => {
+		area.innerHTML = '<span data-contentbefore="[" data-contentafter="]">Hello</span>';
+		Assert.is(area.value, "[Hello]");
+	});
+
+	test("data-content takes precedence over data-contentbefore/data-contentafter", () => {
+		area.innerHTML = '<span data-content="replaced" data-contentbefore="[" data-contentafter="]">Hello</span>';
+		Assert.is(area.value, "replaced");
+	});
+
+	test("mutation inside element with data-contentbefore", () => {
+		area.innerHTML = '<span data-contentbefore=">>> ">Hello</span>';
+		Assert.is(area.value, ">>> Hello");
+
+		const textNode = area.querySelector("span")!.firstChild as Text;
+		textNode.data = "World";
+		Assert.is(area.value, ">>> World");
+	});
+
+	test("attribute change updates value", () => {
+		area.innerHTML = '<span data-contentbefore="A">Hello</span>';
+		Assert.is(area.value, "AHello");
+
+		area.querySelector("span")!.setAttribute("data-contentbefore", "BB");
+		Assert.is(area.value, "BBHello");
+	});
+
+	test("attribute removal detected as deletion", () => {
+		area.innerHTML = '<span data-contentbefore=">>> ">Hello</span>';
+		Assert.is(area.value, ">>> Hello");
+
+		area.querySelector("span")!.removeAttribute("data-contentbefore");
+		Assert.is(area.value, "Hello");
+	});
+
+	test("indexAt/nodeOffsetAt round-trip with data-contentbefore", () => {
+		area.innerHTML = '<span data-contentbefore=">>> ">Hello</span>';
+		Assert.is(area.value, ">>> Hello");
+
+		// Index 0 should round-trip
+		const [node0, offset0] = area.nodeOffsetAt(0);
+		Assert.is(area.indexAt(node0, offset0), 0);
+
+		// Index inside prefix maps to inside the element, before first child
+		const [node1, offset1] = area.nodeOffsetAt(1);
+		Assert.is(node1, area.querySelector("span"));
+		Assert.is(offset1, 0);
+
+		// Index at start of "Hello" (after ">>> ")
+		const [node4, offset4] = area.nodeOffsetAt(4);
+		Assert.is(area.indexAt(node4, offset4), 4);
+
+		// Index in middle of "Hello"
+		const [node6, offset6] = area.nodeOffsetAt(6);
+		Assert.is(area.indexAt(node6, offset6), 6);
+	});
+
+	test("indexAt/nodeOffsetAt round-trip with data-contentafter", () => {
+		area.innerHTML = '<span data-contentafter=" <<<">Hello</span>';
+		Assert.is(area.value, "Hello <<<");
+
+		const [node0, offset0] = area.nodeOffsetAt(0);
+		Assert.is(area.indexAt(node0, offset0), 0);
+
+		const [node5, offset5] = area.nodeOffsetAt(5);
+		Assert.is(area.indexAt(node5, offset5), 5);
+	});
+
+	test("leaf element with data-contentbefore and data-contentafter", () => {
+		area.innerHTML = '<span data-contentbefore="(" data-contentafter=")"></span>';
+		Assert.is(area.value, "()");
+	});
+
+	test("block element with data-contentbefore", () => {
+		area.innerHTML = '<div data-contentbefore="> ">Hello</div>';
+		Assert.is(area.value, "> Hello\n");
+	});
+
+	test("multiple siblings with data-contentbefore/after", () => {
+		area.innerHTML = '<span data-contentbefore="[" data-contentafter="]">A</span><span data-contentbefore="[" data-contentafter="]">B</span>';
+		Assert.is(area.value, "[A][B]");
+	});
+
+	test.run();
+}

--- a/test/contentarea.ts
+++ b/test/contentarea.ts
@@ -1241,6 +1241,10 @@ let area!: ContentAreaElement;
 
 		const [node5, offset5] = area.nodeOffsetAt(5);
 		Assert.is(area.indexAt(node5, offset5), 5);
+
+		// Index inside suffix collapses to children/suffix boundary
+		const [node7, offset7] = area.nodeOffsetAt(7);
+		Assert.is(area.indexAt(node7, offset7), 5);
 	});
 
 	test("leaf element with data-contentbefore and data-contentafter", () => {

--- a/test/contentarea.ts
+++ b/test/contentarea.ts
@@ -1218,10 +1218,11 @@ let area!: ContentAreaElement;
 		const [node0, offset0] = area.nodeOffsetAt(0);
 		Assert.is(area.indexAt(node0, offset0), 0);
 
-		// Index inside prefix maps to inside the element, before first child
+		// Index inside prefix collapses to children/prefix boundary (lossy)
 		const [node1, offset1] = area.nodeOffsetAt(1);
 		Assert.is(node1, area.querySelector("span"));
 		Assert.is(offset1, 0);
+		Assert.is(area.indexAt(node1, offset1), 0);
 
 		// Index at start of "Hello" (after ">>> ")
 		const [node4, offset4] = area.nodeOffsetAt(4);


### PR DESCRIPTION
## Summary

- Add `data-contentbefore` and `data-contentafter` attributes that insert virtual text before/after an element's normal children without replacing them
- Complements the existing `data-content` attribute; `data-content` takes precedence when both are present
- Value ordering: `\n[before]children[after]\n` (structural newlines outermost, virtual text innermost)
- Adds `NodeInfo.beforeLength`/`afterLength` tracking, `diff()` pre/post-order handling, and `findNodeOffset()` cursor positioning support

## Test plan

- [x] All 64 existing + new tests pass
- [x] before-only, after-only, both together
- [x] `data-content` precedence
- [x] Mutations inside elements with before/after text
- [x] Attribute changes and removal
- [x] `indexAt`/`nodeOffsetAt` round-trip
- [x] Leaf and block elements
- [x] Sibling elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)